### PR TITLE
Adjustable offset for TrampolineRoutineWithAppendix

### DIFF
--- a/clever.cc
+++ b/clever.cc
@@ -2942,11 +2942,12 @@ private:
 
                     if(IsTrampolineRoutineWithAppendix(Branch))
                     {
+                        unsigned offset = results[Branch].SpecialTypeParam;
                         unsigned char bank = ROM[Next];
                         KnowledgeAboutMapping guess;
                         guess.guess_for_page[0] = bank*2+0;
                         guess.guess_for_page[1] = bank*2+1;
-                        MarkJumpTable(Next+1, Next+2, 2, 1, {}, 1, guess);
+                        MarkJumpTable(Next+1, Next+2, 2, 1, {}, offset, guess);
                         Mark(Next+3, CertainlyCode, false);
                         Mark(Next+0, CertainlyData, false);
                     }
@@ -3705,9 +3706,11 @@ static void ParseINIfile(FILE* fp, Disassembler& dasm)
         }
         if(tokens[0] == "TrampolineRoutineWithAppendix")
         {
-            if(tokens.size() != 2) goto SyntaxError;
+            if(tokens.size() != 2 && tokens.size() != 3) goto SyntaxError;
             int address = ParseInt(tokens[1]);
-            dasm.SetSpecialType(address, TrampolineRoutineWithAppendix);
+            int offset  = 1; /* Yes, it's inconsistent with JumpTableRoutineWithAppendix. */
+            if(tokens.size() >= 3) offset = ParseInt(tokens[2]);
+            dasm.SetSpecialType(address, TrampolineRoutineWithAppendix, offset);
             continue;
         }
         if(tokens[0] == "MapperChangeRoutine")

--- a/clever/ini-documentation.txt
+++ b/clever/ini-documentation.txt
@@ -188,6 +188,17 @@
          *        The second parameter defines which register holds the high byte of the
          *        address, and the third parameter for the low byte of the address respectively.
          *
+     *   
+     *   Example: CertainlyCode $3C695 TrampolineCall_TrailingParams
+     *            TrampolineRoutineWithAppendix $3C695 1
+     *   
+     *   Allows trampoline-calling to the bank and address which follow.
+     *    
+     *                       ; call routine at $B118 in bank $6
+     *       $E01E 20 95 C6: jsr TrampolineCall_TrailingParams
+     *       $E021 06:       .byte $06
+     *       $E022 17 B1:    .word (_1B118 -1) ;B118
+     *       $E024 60:       rts
 	 *)
 	special-routine-definition =
 		"DataTableRoutineWithXY"  address
@@ -199,7 +210,8 @@
 	                                                      | "RAM"  address
 	                                                      | "reg"  ("A" | "X" | "Y")
 	                                                      )
-	|	"TrampolineRoutine"       address ("A"|"X"|"Y") ("A"|"X"|"Y") ("A"|"X"|"Y");
+	|	"TrampolineRoutine"       address ("A"|"X"|"Y") ("A"|"X"|"Y") ("A"|"X"|"Y")
+	|   "TrampolineRoutineWithAppendix" address [ integer ];
 
 
 


### PR DESCRIPTION
I was disassembling *Monster Maker: 7 Treasures* and I found a routine similar to the one you found in *The Guardian Legend*, but instead of calling a routine at (trailing word-1), it calls the routine at the trailing word directly. `TrampolineRoutineWithAppendix` is what you call this type of routine. `JumpTableRoutineWithAppendix` has an adjustable offset parameter, so I figured that `TrampolineRoutineWithAppendix` ought to as well.

I'm not very content that the default value I chose for the offset of `TrampolineRoutineWithAppendix` is 1 in order to be backward-compatible with your `guardianleg.ini`. It's 0 for `JumpTableRoutineWithAppendix`. Alas.

Anyway... here's my usage for *Monster Maker: 7 Treasures*.

```
CertainlyCode $3C695 Farcall
TrampolineRoutineWithAppendix $3C695 0
```